### PR TITLE
WIP: Use a data volume that does not have to be mounted other container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 nessus-data/var
 nessus-data/etc
 nessus-data/sbin
+nessus-data/mac-address.txt
 
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 nessus-data/var
 nessus-data/etc
 nessus-data/sbin
+
 .DS_Store
 
 # Byte-compiled / optimized / DLL files

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN yum -y update \
       nss-util \
       bind-license \
       libssh2 \
+    && yum -y install \
+      net-tools \
     && yum clean all
 
 # Need Nessus account RPM

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,6 @@ FROM centos:latest
 # https://github.com/sometheycallme
 MAINTAINER Tim Kropp <timkropp77@gmail.com>
 
-# https://github.com/sometheycallme
-MAINTAINER Tim Kropp <timkropp77@gmail.com>
-
-# Update the base image.
-# RUN yum -y update
-
 # Install dependencies.
 RUN yum -y update \
       nss-util \
@@ -27,9 +21,14 @@ RUN yum -y update \
 COPY Nessus-6.4.3-es6.x86_64.rpm /tmp/
 # run the yum install twice as workaround for rpmdb checksum error with overlayfs
 RUN (yum -y --nogpgcheck localinstall /tmp/Nessus-6.4.3-es6.x86_64.rpm || \
-    yum -y --nogpgcheck localinstall /tmp/Nessus-6.4.3-es6.x86_64.rpm) && \
-    yum clean all
+     yum -y --nogpgcheck localinstall /tmp/Nessus-6.4.3-es6.x86_64.rpm) && \
+     yum clean all
 
-# Start Nessus
-ENTRYPOINT ["/opt/nessus/sbin/nessus-service"]
-EXPOSE 8834
+
+# Copy Entrypoint
+COPY 		entrypoint.sh /
+
+EXPOSE 		8834
+VOLUME		[ "/opt/data" ]
+ENTRYPOINT 	[ "/entrypoint.sh" ]
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,29 @@
 #!/bin/bash
-set -x
+#set -x
+
+if [[ -e /opt/data/mac-address.txt ]]; then
+	MYMAC=$(ifconfig eth0|grep ether|awk '{ print $2 }')
+	LICMAC=$(cat /opt/data/mac-address.txt)
+	if [[ "$MYMAC" != "$LICMAC" ]]; then
+		echo "Nessus licensing is based on MAC address."
+		echo "Previous MAC address: $LICMAC"
+		echo "Current MAC address : $MYMAC"
+		echo "Run with docker --mac-address $LICMAC"
+		echo "Or delete max-address.txt from your data volume"
+		exit 255
+	fi
+else
+	ifconfig eth0|grep ether|awk '{ print $2 }' > /opt/data/mac-address.txt
+	echo "Nessus licensing is based on MAC address."
+	echo "This instance will tied to:"
+	cat /opt/data/mac-address.txt
+fi
+
 
 for dir in etc sbin var; do
 	if [[ ! -d /opt/data/$dir ]]; then
 		mkdir /opt/data/$dir
-		(cd /opt/nessus/$dir;tar -cf - .)|(cd /opt/data/$dir;tar -xvf - )
+		(cd /opt/nessus/$dir;tar -cf - .)|(cd /opt/data/$dir;tar -xf - )
 		rm -rf /opt/nessus/$dir
 		ln -s /opt/data/$dir /opt/nessus/$dir
 	fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -x
+
+for dir in etc sbin var; do
+	if [[ ! -d /opt/data/$dir ]]; then
+		mkdir /opt/data/$dir
+		(cd /opt/nessus/$dir;tar -cf - .)|(cd /opt/data/$dir;tar -xvf - )
+		rm -rf /opt/nessus/$dir
+		ln -s /opt/data/$dir /opt/nessus/$dir
+	fi
+done
+
+case $1 in
+	"")
+		/opt/nessus/sbin/nessus-service
+		;;
+	*)
+		exec $@
+		;;
+esac


### PR DESCRIPTION
This may me the much more straight forward way to do it for a lot of people.

Now it is simply a matter of running 

```
docker run -p 8834:8834 -v $(PWD)/nessus-data:/o/data --mac-address 02:42:ac:11:00:01 -ti nessus  /bin/bash

Also, this is compatible with docker-compose which I needed for a demo of
Seccubus at Black Hat Europe.